### PR TITLE
Fix quoting in supervisord export

### DIFF
--- a/honcho/export/templates/supervisord/supervisord.conf
+++ b/honcho/export/templates/supervisord/supervisord.conf
@@ -10,7 +10,7 @@ user={{ user }}
 directory={{ app_root }}
 environment=
     {%- for key,value in p.env.items() -%}
-    {{ key }}={{ value|shellquote|percentescape }}
+    {{ key }}='{{ value|percentescape }}'
     {%- if not loop.last %},{% endif %}
     {%- endfor %}
 


### PR DESCRIPTION
Using the Python shell quoting function doesn't properly work as dashes and other characters are not properly parsed by supervisord.
